### PR TITLE
improve ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 orbs:
   codecov: codecov/codecov@1.0.5

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ jobs:
       - run: go build
 
 workflows:
+  version: 2
   test and build:
     jobs:
       - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,20 +1,26 @@
 version: 2
-jobs:
-  test:
+
+orbs:
+  codecov: codecov/codecov@1.0.5
+
+executors:
+  go-113-5:
     docker:
       - image: circleci/golang:1.13.5-node
     working_directory: /go/src/github.com/kemokemo/try-circle-ci
 
+jobs:
+  test:
+    executor: go-113-5
     steps:
       - checkout
       - run: go version
       - run: go get -v -t -d ./...
-      - run: go test -v -cover ./...
+      - run: go test -v -cover -coverprofile=coverage.out ./...
+      - codecov/upload:
+          file: ./coverage.out
   build:
-    docker:
-      - image: circleci/golang:1.13.5-node
-    working_directory: /go/src/github.com/kemokemo/try-circle-ci
-
+    executor: go-113-5
     steps:
       - checkout
       - run: go get -v -t -d ./...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,8 @@ jobs:
     steps:
       - checkout
       - run: go version
-      - run: go test -v -cover
+      - run: go get -v -t -d ./...
+      - run: go test -v -cover ./...
   build:
     docker:
       - image: circleci/golang:1.13.5-node
@@ -16,4 +17,11 @@ jobs:
 
     steps:
       - checkout
+      - run: go get -v -t -d ./...
       - run: go build
+
+workflows:
+  test and build:
+    jobs:
+      - test
+      - build

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # try-circle-ci
 
+[![CircleCI](https://circleci.com/gh/kemokemo/try-circle-ci.svg?style=svg)](https://circleci.com/gh/kemokemo/try-circle-ci)
+
 A repository to play around with using [CircleCI](https://circleci.com/).


### PR DESCRIPTION
- add workflows
- use ver. 2.1 for reusable executor

special thanks to:

- [ジョブの実行を Workflow で制御する](https://circleci.com/docs/ja/2.0/workflows/)
- [Orbs、ジョブ、ステップ、ワークフロー](https://circleci.com/docs/ja/2.0/jobs-steps/#section=getting-started)
- [再利用可能な Executors のオーサリング](https://circleci.com/docs/ja/2.0/reusing-config/#%E5%86%8D%E5%88%A9%E7%94%A8%E5%8F%AF%E8%83%BD%E3%81%AA-executors-%E3%81%AE%E3%82%AA%E3%83%BC%E3%82%B5%E3%83%AA%E3%83%B3%E3%82%B0)
- [CircleCIのバッジを追加する](https://circleci.com/docs/ja/2.0/status-badges/)