### PR TITLE
docs: add codedev badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # try-circle-ci
 
-[![CircleCI](https://circleci.com/gh/kemokemo/try-circle-ci.svg?style=svg)](https://circleci.com/gh/kemokemo/try-circle-ci)
+[![CircleCI](https://circleci.com/gh/kemokemo/try-circle-ci.svg?style=svg)](https://circleci.com/gh/kemokemo/try-circle-ci) [![codecov](https://codecov.io/gh/kemokemo/try-circle-ci/branch/master/graph/badge.svg)](https://codecov.io/gh/kemokemo/try-circle-ci)
+
+
 
 A repository to play around with using [CircleCI](https://circleci.com/).


### PR DESCRIPTION
special thanks to:

- [CircleCIとCodecovでGitHubにカバレッジバッジをつけよう！](https://medium.com/veltra-engineering/how-to-add-coverage-badge-to-github-repository-using-circleci-and-codecov-663dd412d95f)